### PR TITLE
Add Ansible stuff for provisioning a GCP VM for data publishing purposes.

### DIFF
--- a/cloud/gcp/ansible/playbooks/environments/midas/group_vars/common
+++ b/cloud/gcp/ansible/playbooks/environments/midas/group_vars/common
@@ -1,0 +1,6 @@
+gcp_project: midas-244222
+gcp_cred_kind: serviceaccount
+gcp_cred_file: /tmp/auth.json
+zone: "us-central1-a"
+region: "us-central1"
+

--- a/cloud/gcp/ansible/playbooks/hosts
+++ b/cloud/gcp/ansible/playbooks/hosts
@@ -1,0 +1,6 @@
+[cloud]
+localhost
+
+[cloud:vars]
+ansible_connection=local
+

--- a/cloud/gcp/ansible/playbooks/midas.yaml
+++ b/cloud/gcp/ansible/playbooks/midas.yaml
@@ -1,0 +1,8 @@
+- name: Create an instance
+  hosts: cloud
+  gather_facts: no
+  vars_files:
+    - "environments/midas/group_vars/common"
+  roles:
+    - create_midas_data_vm
+

--- a/cloud/gcp/ansible/playbooks/roles/create_midas_data_vm/tasks/main.yaml
+++ b/cloud/gcp/ansible/playbooks/roles/create_midas_data_vm/tasks/main.yaml
@@ -1,0 +1,60 @@
+- name: Create a disk
+  gcp_compute_disk:
+   name: 'midas-vm-disk'
+   size_gb: 15
+   source_image: 'projects/centos-cloud/global/images/centos-7-v20190619'
+   zone: "{{ zone }}"
+   project: "{{ gcp_project }}"
+   auth_kind: "{{ gcp_cred_kind }}"
+   service_account_file: "{{ gcp_cred_file }}"
+   scopes:
+     - https://www.googleapis.com/auth/compute
+   state: present
+  register: disk
+
+- name: Create a network
+  gcp_compute_network:
+   name: 'midas-vm-network'
+   project: "{{ gcp_project }}"
+   auth_kind: "{{ gcp_cred_kind }}"
+   service_account_file: "{{ gcp_cred_file }}"
+   scopes:
+     - https://www.googleapis.com/auth/compute
+   state: present
+  register: network
+
+- name: Create an address
+  gcp_compute_address:
+   name: 'midas-vm-address'
+   region: "{{ region }}"
+   project: "{{ gcp_project }}"
+   auth_kind: "{{ gcp_cred_kind }}"
+   service_account_file: "{{ gcp_cred_file }}"
+   scopes:
+     - https://www.googleapis.com/auth/compute
+   state: present
+  register: address
+
+- name: Create an instance
+  gcp_compute_instance:
+   state: present
+   name: midas-data-vm
+   machine_type: n1-standard-1
+   disks:
+     - auto_delete: true
+       boot: true
+       source: "{{ disk }}"
+   network_interfaces:
+     - network: "{{ network }}"
+       access_configs:
+         - name: 'External NAT'
+           nat_ip: "{{ address }}"
+           type: 'ONE_TO_ONE_NAT'
+   zone: "{{ zone }}"
+   project: "{{ gcp_project }}"
+   auth_kind: "{{ gcp_cred_kind }}"
+   service_account_file: "{{ gcp_cred_file }}"
+   scopes:
+     - https://www.googleapis.com/auth/compute
+  register: instance
+

--- a/cloud/gcp/ansible/prepare_ansible_environment.sh
+++ b/cloud/gcp/ansible/prepare_ansible_environment.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+xargs sudo yum -y install < yum-requirements.txt
+sudo pip install -r requirements.txt
+
+# Run a playbook.
+# ansible-playbook -i hosts midas.yaml
+

--- a/cloud/gcp/ansible/requirements.txt
+++ b/cloud/gcp/ansible/requirements.txt
@@ -1,0 +1,2 @@
+google-auth
+requests

--- a/cloud/gcp/ansible/yum-requirements.txt
+++ b/cloud/gcp/ansible/yum-requirements.txt
@@ -1,0 +1,2 @@
+ansible 
+python-pip


### PR DESCRIPTION
This commit adds playbooks, vars, and roles for the provisioning of a GCP VM for data publishing through Ansible.