### PR TITLE
Add rudimentary Prometheus calls to local NodeJS.

### DIFF
--- a/midas/package-lock.json
+++ b/midas/package-lock.json
@@ -26,6 +26,11 @@
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
+    "bintrees": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.1.tgz",
+      "integrity": "sha1-DmVcm5wkNeqraL9AJyJtK1WjRSQ="
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -573,6 +578,11 @@
         "ee-first": "1.1.1"
       }
     },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+    },
     "one-by-one": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/one-by-one/-/one-by-one-3.2.7.tgz",
@@ -670,6 +680,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
+    },
+    "prom-client": {
+      "version": "11.5.3",
+      "resolved": "https://registry.npmjs.org/prom-client/-/prom-client-11.5.3.tgz",
+      "integrity": "sha512-iz22FmTbtkyL2vt0MdDFY+kWof+S9UB/NACxSn2aJcewtw+EERsen0urSkZ2WrHseNdydsvcxCTAnPcSMZZv4Q==",
+      "requires": {
+        "tdigest": "^0.1.1"
+      }
     },
     "protocols": {
       "version": "1.4.7",
@@ -803,6 +821,15 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
+    "response-time": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
+      "integrity": "sha1-/6cbq5UtYvfB1Jt0NDVfvGjf/Fo=",
+      "requires": {
+        "depd": "~1.1.0",
+        "on-headers": "~1.0.1"
+      }
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -929,6 +956,14 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+    },
+    "tdigest": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tdigest/-/tdigest-0.1.1.tgz",
+      "integrity": "sha1-Ljyyw56kSeVdHmzZEReszKRYgCE=",
+      "requires": {
+        "bintrees": "1.0.1"
+      }
     },
     "timed-out": {
       "version": "3.1.3",

--- a/midas/package.json
+++ b/midas/package.json
@@ -10,7 +10,9 @@
     "highcharts": "^7.1.2",
     "mongodb": "^3.2.7",
     "mustache": "^3.0.1",
-    "package.json": "^2.0.1"
+    "package.json": "^2.0.1",
+    "prom-client": "^11.5.3",
+    "response-time": "^2.3.2"
   },
   "devDependencies": {},
   "scripts": {

--- a/midas/prometheus/prometheus.yml
+++ b/midas/prometheus/prometheus.yml
@@ -1,0 +1,9 @@
+scrape_configs:
+  - job_name: 'midas-web'
+    scrape_interval: 5s
+
+    static_configs:
+      - targets: ['127.0.0.1:80']
+        labels:
+          service: 'midas'
+          group: 'local'

--- a/midas/server.js
+++ b/midas/server.js
@@ -8,6 +8,9 @@ var argv = require('minimist')(process.argv.slice(2));
 var mongoAccessorString = "mongodb://" + argv["database_info"];
 
 // Handle database interactions.
+// For local testing: run a mongodb instance either in the background or another window.
+// For example, on Windows, this looks like: C:\"Program Files"\MongoDB\Server\4.0\bin\mongo.exe
+// You can then see the UI in your browser with 127.0.0.1/x.
 var MongoClient = require('mongodb').MongoClient;
 var databaseName = "financial_data_db";
 var client = new MongoClient(mongoAccessorString);
@@ -38,11 +41,39 @@ var app = express();
 app.set('view engine', 'ejs');
 app.use(express.static(path.join(__dirname, 'templates')));
 
-// Main entry point for web page.
+// Set up Prometheus instrumentation for app performance.
+const Prometheus = require('prom-client');
+var responseTime = require('response-time')
+
+const httpRequestDurationMicroseconds = new Prometheus.Histogram({
+  name: 'http_request_duration_ms',
+  help: 'Duration of HTTP requests in ms',
+  labelNames: ['route'],
+  // RT in interval [0.1, 500] ms
+  buckets: [0.10, 5, 15, 50, 100, 200, 300, 400, 500]
+});
+
+app.use(responseTime(function(req, res, time) {
+    try {
+        httpRequestDurationMicroseconds
+        .labels(req.route.path)
+        .observe(time);
+    } catch (error) {
+        console.log(error);
+    }
+}));
+
+// Entry point for main web page.
 app.get('/home', function(req, res) {
     overallDataPromise().then(function(result) {
         res.render('home.ejs', { overallFinancialSeries: result });
     });
 });
+
+// Endpoint to view Prometheus metrics.
+app.get('/metrics', (req, res) => {
+  res.set('Content-Type', Prometheus.register.contentType)
+  res.end(Prometheus.register.metrics())
+})
 
 app.listen(80);


### PR DESCRIPTION
Mostly functions as a proof of concept of the NodeJS Prometheus exporter. More interesting data should be logged in the future. Additionally, cloud support would be nice, for example a Prometheus pod that logs the results of the web service.